### PR TITLE
tfestimators moved to conda install

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,13 +7,14 @@ USER root
 RUN conda install -c conda-forge -y\
     r-arrow\
     r-rjdbc\
+    r-tfestimators\
     openjdk">=17.0.14,<18.0.0"
 
 
 #Configure R/openjdk for arrow
 RUN R CMD javareconf
 
-RUN R -e "install.packages(c('aws.s3', 'bench', 'bookdown', 'ff', 'foreach', 'future', 'gamlr', 'keras', 'scattermore', 'tensorflow', 'tfestimators'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
+RUN R -e "install.packages(c('aws.s3', 'bench', 'bookdown', 'ff', 'foreach', 'future', 'gamlr', 'keras', 'scattermore', 'tensorflow'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
 
 RUN R -e "devtools::install_github('edwindj/ffbase', subdir='pkg')"
 


### PR DESCRIPTION
tfestimators removed - https://cran.r-project.org/web/packages/tfestimators/index.html

> Archived on 2025-06-13 as issues were not corrected despite reminders.

r-tfestimators
https://anaconda.org/conda-forge/r-tfestimators 
